### PR TITLE
feat: Add event modal with teacher info and read more functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # ExoClass Calendar Plugin - Versijų istorija
 
+## [1.2.1] - 2025-08-05
+### Pridėta
+- Event details modal su išsamiu informacijos rodymu
+- Teacher dropdown filtras kalendoriuje
+- Teacher informacijos rodymas event modal'e
+- "Read more" funkcionalumas teacher aprašymui
+- "Read more" funkcionalumas event aprašymui su YouTube iframe palaikymu
+- Dinaminis iframe aukščio skaičiavimas modal'e
+- Address rodymas vietoj dance hall pavadinimo location dropdown'e
+- Address trumpinimas (pašalintas šalis ir pašto kodas, palikta miesto pavadinimas)
+
+### Pakeista
+- Event click elgsena: dabar atidaro modal vietoj tiesioginio nukreipimo
+- Teacher aprašymo stilius: pašalintas background ir border
+- Teacher aprašymo pozicija: dabar rodomas po event aprašymo
+- Location dropdown: dabar rodo adresą vietoj dance hall pavadinimo
+- Teacher dropdown: pridėtas naujas filtras kalendoriuje
+
+### Pataisyta
+- Modal close button funkcionalumas
+- Teacher aprašymo "read more" mygtuko pozicija
+- Dinaminis iframe aukščio skaičiavimas modal'e
+
 ## [1.2.0] - 2024-01-16
 ### Pridėta
 - Pilna GitHub releases integracija automatiniams atnaujinimams

--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -865,10 +865,65 @@ th.fc-day-today {
 }
 
 .event-modal-description {
-    margin-bottom: 70px;
+    margin-bottom: 20px;
     font-size: 14px;
     line-height: 1.6;
     color: #333;
+}
+
+.event-modal-teacher-info {
+    margin-bottom: 80px;
+}
+
+.event-modal-teacher-info h2 {
+    margin: 0 0 10px 0;
+    font-size: 16px;
+    color: #333;
+    font-weight: 600;
+}
+
+.teacher-description {
+    font-size: 14px;
+    line-height: 1.6;
+    color: #555;
+}
+
+.teacher-description {
+    max-height: 77px;
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+}
+
+.teacher-description.expanded {
+    max-height: max-content;
+}
+
+.read-more-btn {
+    background: none;
+    border: none;
+    color: #FA6418;
+    cursor: pointer;
+    font-size: 14px;
+    padding: 5px 0;
+    margin-top: 10px;
+    transition: all 0.3s ease;
+}
+
+.read-more-btn:hover {
+    color: #000000;
+}
+
+.description-content {
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+}
+
+.description-content.expanded {
+    max-height: max-content !important;
+}
+
+.description-read-more {
+    display: none;
 }
 
 .event-modal-actions {

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -181,11 +181,80 @@
                 
                 // Update description if available
                 const $descriptionEl = $modal.find('.event-modal-description');
+                const $descriptionContent = $modal.find('.description-content');
+                const $descriptionReadMore = $modal.find('.description-read-more');
+                
                 if (props.activityData && props.activityData.description) {
-                    $descriptionEl.html(props.activityData.description);
+                    $descriptionContent.html(props.activityData.description);
                     $descriptionEl.show();
+                    
+                    // Calculate dynamic max height based on iframe
+                    setTimeout(() => {
+                        const $iframe = $descriptionContent.find('iframe');
+                        const iframeHeight = $iframe.outerHeight() || 0;
+                        const textHeight = $descriptionContent.find('p, div:not(:has(iframe))').outerHeight() || 0;
+                        
+                        // Calculate dynamic max height: iframe height + text height + some padding
+                        let dynamicMaxHeight = iframeHeight + textHeight + 100; // 50px padding
+                        
+                        // Minimum height of 200px, maximum of 400px
+                        dynamicMaxHeight = Math.max(250, Math.min(550, dynamicMaxHeight));
+                        
+                        // Set the dynamic max height via CSS
+                        $descriptionContent.css('max-height', dynamicMaxHeight + 'px');
+                        
+                        // Check if we need read more button
+                        const contentHeight = $descriptionContent[0].scrollHeight;
+                        
+                        if (contentHeight > dynamicMaxHeight) {
+                            $descriptionReadMore.show();
+                        } else {
+                            $descriptionReadMore.hide();
+                        }
+                    }, 200); // Longer delay to ensure iframe is fully loaded
                 } else {
                     $descriptionEl.hide();
+                }
+                
+                // Update teacher information if available
+                const $teacherInfo = $modal.find('.event-modal-teacher-info');
+                const $teacherDescriptionContent = $modal.find('.teacher-description-content');
+                const $readMoreBtn = $modal.find('.read-more-btn');
+                
+                if (props.teacherData) {
+                    // Create teacher description from available data
+                    let teacherDescription = '';
+                    
+                    // Check for employee_provider description (rich teacher bio)
+                    if (props.teacherData.employee_provider && props.teacherData.employee_provider.description) {
+                        teacherDescription = props.teacherData.employee_provider.description;
+                    } else if (props.teacherData.bio) {
+                        teacherDescription = props.teacherData.bio;
+                    } else if (props.teacherData.description) {
+                        teacherDescription = props.teacherData.description;
+                    } else {
+                        // Create a basic description from available info
+                        const teacherName = props.teacher || 'Treneris';
+                        teacherDescription = `${teacherName} yra patyręs ir kvalifikuotas treneris, specializuojantis šioje veikloje.`;
+                    }
+                    
+                    if (teacherDescription) {
+                        // Set the full description
+                        $teacherDescriptionContent.html(teacherDescription);
+                        
+                        // Show/hide read more button based on content length
+                        if (teacherDescription.length > 200) {
+                            $readMoreBtn.show();
+                        } else {
+                            $readMoreBtn.hide();
+                        }
+                        
+                        $teacherInfo.show();
+                    } else {
+                        $teacherInfo.hide();
+                    }
+                } else {
+                    $teacherInfo.hide();
                 }
                 
                 // Update registration button
@@ -859,5 +928,35 @@
             }
         }
     }
+    
+    // Simple read more functionality for teacher description
+    $(document).on('click', '.read-more-btn', function() {
+        const $btn = $(this);
+        
+        // Check if it's for teacher description or event description
+        if ($btn.hasClass('description-read-more')) {
+            // Handle event description
+            const $desc = $btn.siblings('.description-content');
+            
+            if ($desc.hasClass('expanded')) {
+                $desc.removeClass('expanded');
+                $btn.text('Skaityti daugiau');
+            } else {
+                $desc.addClass('expanded');
+                $btn.text('Rodyti mažiau');
+            }
+        } else {
+            // Handle teacher description
+            const $desc = $btn.siblings('.teacher-description');
+            
+            if ($desc.hasClass('expanded')) {
+                $desc.removeClass('expanded');
+                $btn.text('Skaityti daugiau');
+            } else {
+                $desc.addClass('expanded');
+                $btn.text('Rodyti mažiau');
+            }
+        }
+    });
     
 })(jQuery); 

--- a/exoclass-calendar.php
+++ b/exoclass-calendar.php
@@ -234,7 +234,16 @@ class ExoClassCalendar {
                                 <span class="event-difficulty"></span>
                             </div>
                         </div>
-                        <div class="event-modal-description"></div>
+                        <div class="event-modal-description">
+                            <div class="description-content"></div>
+                            <button class="read-more-btn description-read-more"><?php _e('Skaityti daugiau', 'exoclass-calendar'); ?></button>
+                        </div>
+                        <div class="event-modal-teacher-info" style="display: none;">
+                            <div class="teacher-description">
+                                <div class="teacher-description-content"></div>
+                            </div>
+                            <button class="read-more-btn"><?php _e('Skaityti daugiau', 'exoclass-calendar'); ?></button>
+                        </div>
                         <div class="event-modal-actions">
                             <a href="#" class="register-button" target="_blank"><?php _e('Registruotis', 'exoclass-calendar'); ?></a>
                         </div>
@@ -336,6 +345,7 @@ class ExoClassCalendar {
                         'end' => $session['end_time'],
                         'extendedProps' => array(
                             'teacher' => $teacher,
+                            'teacherData' => $this->get_teacher_data($group),
                             'availableSpots' => $available_spots,
                             'maxSpots' => $max_spots,
                             'activityName' => $activity_name,
@@ -425,6 +435,23 @@ class ExoClassCalendar {
         }
         
         return __('Treneris', 'exoclass-calendar');
+    }
+    
+    private function get_teacher_data($group) {
+        // Try to get teacher info from the 'teachers' array
+        if (isset($group['teachers']) && is_array($group['teachers']) && !empty($group['teachers'])) {
+            $teacher = $group['teachers'][0];
+            // Return the whole teacher array (contains bio/description if available)
+            return $teacher;
+        }
+        // Fallbacks if needed
+        if (isset($group['staff']) && is_array($group['staff']) && !empty($group['staff'])) {
+            return $group['staff'][0];
+        }
+        if (isset($group['instructor'])) {
+            return $group['instructor'];
+        }
+        return null;
     }
 }
 


### PR DESCRIPTION
- Add event details modal with comprehensive information display
- Add teacher dropdown filter in calendar
- Add teacher information display in event modal
- Add read more functionality for teacher descriptions
- Add read more functionality for event descriptions with YouTube iframe support
- Add dynamic iframe height calculation in modal
- Change location dropdown to show address instead of dance hall name
- Shorten address display (remove country and postal code, keep city name)
- Update event click behavior to open modal instead of direct redirect
- Fix modal close button functionality
- Fix teacher description read more button positioning
- Update version to 1.2.1